### PR TITLE
Fixes typo in EN poster text

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -7,7 +7,7 @@ en:
   no_calls: "No Phone Calls"
   install: "Install Bridgefy"
   moreinfo: "More Information"
-  intro: "This app allows people to chat via BLUETOOTH. Messages hop through phones of people around you, so the more people have Bridgefy on their phones, the stronger the network. Install and test with friends before you step you."
+  intro: "This app allows people to chat via BLUETOOTH. Messages hop through phones of people around you, so the more people have Bridgefy on their phones, the stronger the network. Install and test with friends before you step out."
   android_link: "Install on Android"
   ios_link: "Install on iOS"
   apk_link: "Download APK"


### PR DESCRIPTION
Fixes small typo in `en.yml`
`before you step you.` -> `before you step out.`